### PR TITLE
Implement passport OCR module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Odoo-Pasaporte
+# Odoo Pasaporte Module
+
+This repository contains an example Odoo module to manage passports.
+It includes OCR extraction, expiration notifications and security rules.
+See `partner_passport/README.md` for module details.

--- a/partner_passport/README.md
+++ b/partner_passport/README.md
@@ -1,0 +1,21 @@
+# Partner Passport OCR
+
+This module adds basic passport management with OCR capabilities.
+
+## Requirements
+- Odoo 16.0 or newer
+- Python packages: `pytesseract`, `Pillow`
+- System package: `tesseract-ocr`
+
+## Usage
+1. Install the module in Odoo.
+2. Attach a scanned passport image to a passport record.
+3. Click **Scan Passport** to populate fields using OCR.
+4. A scheduled job checks expirations daily and posts messages on the contact.
+
+## Cron
+The job `Passport Expiry Check` runs every day and notifies when a passport is
+expired or near expiration (30/90/180/360 days).
+
+## Permissions
+Only members of the **Passport Officer** group can scan or edit passport data.

--- a/partner_passport/__init__.py
+++ b/partner_passport/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/partner_passport/__manifest__.py
+++ b/partner_passport/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Partner Passport OCR',
+    'summary': 'Manage passports and OCR scanning',
+    'version': '1.0',
+    'author': 'Example',
+    'depends': ['base'],
+    'data': [
+        'security/security.xml',
+        'security/ir.model.access.csv',
+        'data/cron.xml',
+        'views/res_partner_passport_views.xml',
+    ],
+    'installable': True,
+}

--- a/partner_passport/data/cron.xml
+++ b/partner_passport/data/cron.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_passport_expiry" model="ir.cron">
+            <field name="name">Passport Expiry Check</field>
+            <field name="model_id" ref="model_res_partner_passport"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_check_passport_expiry()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+        </record>
+    </data>
+</odoo>

--- a/partner_passport/models/__init__.py
+++ b/partner_passport/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner_passport

--- a/partner_passport/models/res_partner_passport.py
+++ b/partner_passport/models/res_partner_passport.py
@@ -1,0 +1,134 @@
+import base64
+import io
+import re
+
+from datetime import date
+
+from PIL import Image, ImageOps, ImageEnhance
+import pytesseract
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError, UserError
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    passport_id = fields.Many2one('res.partner.passport', string='Passport')
+
+
+class ResPartnerPassport(models.Model):
+    """Passport model with OCR support and expiry checks."""
+
+    _name = 'res.partner.passport'
+    _description = 'Partner Passport'
+
+    partner_id = fields.Many2one('res.partner', required=True, ondelete='cascade')
+    number = fields.Char(string='Passport Number')
+    issue_date = fields.Date()
+    expiry_date = fields.Date()
+    image = fields.Binary(string='Passport Image')
+    state = fields.Selection([
+        ('active', 'Active'),
+        ('archived', 'Archived')
+    ], default='active')
+
+    # Link back to partner for easy access
+    passport_ref = fields.One2many('res.partner', 'passport_id', string='Partners')
+
+    _sql_constraints = [
+        ('number_unique', 'unique(number)', 'Passport number must be unique!'),
+    ]
+
+    def _preprocess_image(self, img_data):
+        """Prepare image for OCR using grayscale, contrast and threshold."""
+        image = Image.open(io.BytesIO(base64.b64decode(img_data)))
+        gray = ImageOps.grayscale(image)
+        contrast = ImageEnhance.Contrast(gray).enhance(2.0)
+        thresh = contrast.point(lambda p: 255 if p > 128 else 0)
+        return thresh
+
+    def _extract_mrz(self, text):
+        lines = [l for l in text.splitlines() if len(l) > 40]
+        if len(lines) >= 2:
+            mrz = ''.join(lines[-2:])
+            return mrz
+        return ''
+
+    def _parse_mrz(self, mrz):
+        """Parse MRZ string using simple regex to fetch number and dates."""
+        match = re.search(r'([A-Z0-9<]{9})(\d{6})(\d{6})', mrz)
+        if not match:
+            return {}
+        number = match.group(1).replace('<', '')
+        issue = match.group(2)
+        expiry = match.group(3)
+        def _fmt(date_str):
+            year = int(date_str[:2])
+            year += 2000 if year < 70 else 1900
+            return date(year, int(date_str[2:4]), int(date_str[4:6]))
+        return {
+            'number': number,
+            'issue_date': _fmt(issue),
+            'expiry_date': _fmt(expiry),
+        }
+
+    def action_scan_passport(self):
+        """Run OCR on stored passport image and fill fields."""
+        for passport in self:
+            if not passport.image:
+                raise UserError(_('No image attached to this passport.'))
+            img = passport._preprocess_image(passport.image)
+            text = pytesseract.image_to_string(img, lang='eng+fra+spa')
+            mrz = passport._extract_mrz(text)
+            data = passport._parse_mrz(mrz)
+            for key, value in data.items():
+                passport[key] = value
+
+    @api.constrains('expiry_date')
+    def _check_expiry_date(self):
+        for rec in self:
+            if rec.expiry_date and rec.expiry_date < fields.Date.today():
+                rec.partner_id.message_post(body=_('Passport expired on %s') % rec.expiry_date)
+
+    def _cron_check_passport_expiry(self):
+        """Daily job to notify about passports nearing expiration."""
+        today = fields.Date.today()
+        for passport in self.search([('state', '=', 'active'), ('expiry_date', '!=', False)]):
+            delta = (passport.expiry_date - today).days
+            if delta < 0:
+                tag = 'Pasaporte vencido'
+            elif delta <= 30:
+                tag = 'Pasaporte por vencer (30 d\xedas)'
+            elif delta <= 90:
+                tag = 'Pasaporte por vencer (90 d\xedas)'
+            elif delta <= 180:
+                tag = 'Pasaporte por vencer (180 d\xedas)'
+            elif delta <= 360:
+                tag = 'Pasaporte por vencer (360 d\xedas)'
+            else:
+                tag = False
+            if tag:
+                passport.partner_id.message_post(body=_(tag))
+
+
+class TravelTrip(models.Model):
+    """Sample trip model to demonstrate warnings when adding passengers."""
+
+    _name = 'travel.trip'
+    _description = 'Travel Trip'
+
+    name = fields.Char(required=True)
+    partner_ids = fields.Many2many('res.partner')
+
+    @api.constrains('partner_ids')
+    def _check_partner_passports(self):
+        for trip in self:
+            expired = trip.partner_ids.filtered(
+                lambda p: p.passport_id and p.passport_id.expiry_date and p.passport_id.expiry_date < fields.Date.today()
+            )
+            if expired:
+                names = ', '.join(expired.mapped('name'))
+                raise ValidationError(_(
+                    'These partners have expired passports: %s. Please update before confirming the trip.'
+                ) % names)

--- a/partner_passport/security/ir.model.access.csv
+++ b/partner_passport/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_res_partner_passport,access_res_partner_passport,model_res_partner_passport,base.group_user,1,0,0,0
+access_res_partner_passport_officer,access_res_partner_passport_officer,model_res_partner_passport,partner_passport.group_passport_officer,1,1,1,1

--- a/partner_passport/security/security.xml
+++ b/partner_passport/security/security.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data noupdate="1">
+        <record id="group_passport_officer" model="res.groups">
+            <field name="name">Passport Officer</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+    </data>
+</odoo>

--- a/partner_passport/views/res_partner_passport_views.xml
+++ b/partner_passport/views/res_partner_passport_views.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <record id="view_res_partner_passport_form" model="ir.ui.view">
+        <field name="name">res.partner.passport.form</field>
+        <field name="model">res.partner.passport</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="partner_id"/>
+                        <field name="number"/>
+                        <field name="issue_date"/>
+                        <field name="expiry_date"/>
+                        <field name="image" widget="image"/>
+                        <button name="action_scan_passport" type="object" string="Scan Passport" groups="partner_passport.group_passport_officer"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add basic passport OCR module with cron
- define passport model and scanning action
- schedule expiry notifications
- add security group and access rules
- document module usage

## Testing
- `python3 -m compileall -q partner_passport`

------
https://chatgpt.com/codex/tasks/task_e_6858c1ba65a0832c9742d7a3fbc7defa