### PR TITLE
Add passport reader module with OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Odoo-Pasaporte
+# Odoo Passport Reader
+
+This repository contains a sample Odoo 17 module `passport_reader` which can
+read passports from images or PDF files using OCR. It manages expiration dates
+and keeps multiple passports for a contact.
+
+Install the Python dependencies from `requirements.txt` and ensure the
+`tesseract-ocr` binary is available in the system.

--- a/passport_reader/README.md
+++ b/passport_reader/README.md
@@ -1,0 +1,4 @@
+# Passport Reader
+
+Odoo module to read passports using OCR. Requires `pytesseract` and the
+Tesseract OCR binary. If PDF files are used, `pdf2image` is also needed.

--- a/passport_reader/__init__.py
+++ b/passport_reader/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/passport_reader/__manifest__.py
+++ b/passport_reader/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Passport Reader',
+    'version': '0.1',
+    'summary': 'Read passports using OCR and manage expirations',
+    'category': 'Tools',
+    'author': 'Example',
+    'depends': ['base'],
+    'data': [
+        'views/passport_reader_views.xml',
+    ],
+    'installable': True,
+}

--- a/passport_reader/models/__init__.py
+++ b/passport_reader/models/__init__.py
@@ -1,0 +1,1 @@
+from . import passport_reader

--- a/passport_reader/models/passport_reader.py
+++ b/passport_reader/models/passport_reader.py
@@ -1,0 +1,107 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+import base64
+import io
+from datetime import datetime, timedelta
+
+try:
+    import pytesseract
+except ImportError:  # pragma: no cover - dependency may not be installed
+    pytesseract = None
+
+try:
+    from pdf2image import convert_from_bytes
+except ImportError:  # pragma: no cover
+    convert_from_bytes = None
+
+from PIL import Image
+
+class PassportReader(models.Model):
+    _name = 'passport.reader'
+    _description = 'Passport Reader'
+
+    name = fields.Char('Name')
+    contact_id = fields.Many2one('res.partner', string='Contact')
+    file = fields.Binary(string='Passport File', attachment=True)
+    file_filename = fields.Char()
+    passport_number = fields.Char()
+    expiration_date = fields.Date()
+
+    _sql_constraints = [
+        ('passport_contact_unique', 'unique(contact_id, passport_number)',
+         'A passport with this number already exists for this contact.'),
+    ]
+
+    def is_expired(self):
+        self.ensure_one()
+        if self.expiration_date:
+            return fields.Date.today() > self.expiration_date
+        return False
+
+    def is_expiring_soon(self):
+        self.ensure_one()
+        if self.expiration_date:
+            soon = fields.Date.today() + timedelta(days=60)
+            return fields.Date.today() <= self.expiration_date <= soon
+        return False
+
+    def _extract_text_from_file(self):
+        if not self.file:
+            raise UserError(_('No file to process.'))
+        if not pytesseract:
+            raise UserError(_('pytesseract is not installed.'))
+        binary = base64.b64decode(self.file)
+        filename = (self.file_filename or '').lower()
+        images = []
+        if filename.endswith('.pdf'):
+            if not convert_from_bytes:
+                raise UserError(_('pdf2image is not installed.'))
+            images = convert_from_bytes(binary)
+        else:
+            images = [Image.open(io.BytesIO(binary))]
+        text = ''
+        for img in images:
+            text += pytesseract.image_to_string(img)
+        return text
+
+    def parse_passport_text(self, text):
+        # Very naive MRZ parser for demonstration
+        if not text:
+            return
+        lines = [l.strip() for l in text.splitlines() if l.strip()]
+        mrz_lines = [l for l in lines if l.startswith('P<')]
+        if mrz_lines:
+            idx = lines.index(mrz_lines[0])
+            if len(lines) > idx + 1:
+                second = lines[idx + 1]
+                self.passport_number = second[0:9].replace('<', '')
+        # Fallback: try to find a number pattern
+        if not self.passport_number:
+            for line in lines:
+                if line.isalnum() and len(line) >= 6:
+                    self.passport_number = line
+                    break
+
+    def action_read_passport(self):
+        for record in self:
+            text = record._extract_text_from_file()
+            if not text:
+                raise UserError(_('Could not read passport.'))
+            record.parse_passport_text(text)
+        return True
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record in records:
+            if record.is_expired():
+                raise UserError(_('Passport is expired.'))
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        for record in self:
+            if record.is_expired():
+                raise UserError(_('Passport is expired.'))
+        return res

--- a/passport_reader/views/passport_reader_views.xml
+++ b/passport_reader/views/passport_reader_views.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_passport_reader_form" model="ir.ui.view">
+        <field name="name">passport.reader.form</field>
+        <field name="model">passport.reader</field>
+        <field name="arch" type="xml">
+            <form string="Passport Reader">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="contact_id"/>
+                        <field name="passport_number"/>
+                        <field name="expiration_date"/>
+                        <field name="file" filename="file_filename"/>
+                    </group>
+                    <footer>
+                        <button name="action_read_passport" type="object" string="📷 Leer pasaporte" class="btn-primary"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_passport_reader_tree" model="ir.ui.view">
+        <field name="name">passport.reader.tree</field>
+        <field name="model">passport.reader</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="contact_id"/>
+                <field name="passport_number"/>
+                <field name="expiration_date"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_passport_reader" model="ir.actions.act_window">
+        <field name="name">Passport Readers</field>
+        <field name="res_model">passport.reader</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_passport_reader_root" name="Passport"/>
+    <menuitem id="menu_passport_reader" name="Passport Readers" parent="menu_passport_reader_root" action="action_passport_reader"/>
+</odoo>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytesseract
+pdf2image
+Pillow


### PR DESCRIPTION
## Summary
- create `passport_reader` module that reads passport files using pytesseract
- store expiration dates and simple duplicate checks
- add views and README
- document installation requirements

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858bd991558832cb4a1bba6dd1dacf8