### PR TITLE
Implement passport validation and history

### DIFF
--- a/passport_reader/__manifest__.py
+++ b/passport_reader/__manifest__.py
@@ -6,7 +6,9 @@
     'author': 'Example',
     'depends': ['base'],
     'data': [
+        'security/ir.model.access.csv',
         'views/passport_reader_views.xml',
+        'views/res_partner_views.xml',
     ],
     'installable': True,
 }

--- a/passport_reader/models/__init__.py
+++ b/passport_reader/models/__init__.py
@@ -1,1 +1,3 @@
 from . import passport_reader
+from . import res_partner
+from . import passport_history

--- a/passport_reader/models/passport_history.py
+++ b/passport_reader/models/passport_history.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+class PassportHistory(models.Model):
+    _name = 'passport.history'
+    _description = 'Passport History'
+    _order = 'date desc'
+
+    partner_id = fields.Many2one('res.partner', required=True, ondelete='cascade')
+    old_passport_number = fields.Char()
+    old_expiration_date = fields.Date()
+    date = fields.Datetime(default=fields.Datetime.now)
+    user_id = fields.Many2one('res.users', default=lambda self: self.env.user)

--- a/passport_reader/models/passport_reader.py
+++ b/passport_reader/models/passport_reader.py
@@ -83,12 +83,25 @@ class PassportReader(models.Model):
                     self.passport_number = line
                     break
 
+        # Duplicate validation after parsing
+        if self.passport_number:
+            existing = self.env['res.partner'].search([
+                ('passport_number', '=', self.passport_number)
+            ], limit=1)
+            if existing:
+                raise UserError(_('Ya existe un contacto con este número de pasaporte.'))
+
     def action_read_passport(self):
         for record in self:
             text = record._extract_text_from_file()
             if not text:
                 raise UserError(_('Could not read passport.'))
             record.parse_passport_text(text)
+            if record.contact_id:
+                record.contact_id.write({
+                    'passport_number': record.passport_number,
+                    'passport_expiration_date': record.expiration_date,
+                })
         return True
 
     @api.model_create_multi
@@ -100,6 +113,9 @@ class PassportReader(models.Model):
         return records
 
     def write(self, vals):
+        if 'file' in vals:
+            vals.setdefault('passport_number', False)
+            vals.setdefault('expiration_date', False)
         res = super().write(vals)
         for record in self:
             if record.is_expired():

--- a/passport_reader/models/res_partner.py
+++ b/passport_reader/models/res_partner.py
@@ -1,0 +1,60 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    passport_number = fields.Char(string='Passport Number')
+    passport_expiration_date = fields.Date(string='Passport Expiration Date')
+    passport_status = fields.Selection([
+        ('valid', 'Valid'),
+        ('expiring', 'Expiring'),
+        ('expired', 'Expired')
+    ], string='Passport Status', compute='_compute_passport_status', store=True)
+    passport_history_ids = fields.One2many('passport.history', 'partner_id', string='Passport History')
+
+    @api.depends('passport_expiration_date')
+    def _compute_passport_status(self):
+        today = fields.Date.today()
+        for partner in self:
+            status = False
+            if partner.passport_expiration_date:
+                delta = partner.passport_expiration_date - today
+                if delta.days < 0:
+                    status = 'expired'
+                elif delta.days <= 360:
+                    status = 'expiring'
+                else:
+                    status = 'valid'
+            partner.passport_status = status
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            number = vals.get('passport_number')
+            if number and self.search([('passport_number', '=', number)], limit=1):
+                raise ValidationError(_('Ya existe un contacto con este número de pasaporte.'))
+        partners = super().create(vals_list)
+        return partners
+
+    def write(self, vals):
+        if 'passport_number' in vals:
+            for partner in self:
+                number = vals.get('passport_number')
+                if number and self.env['res.partner'].search([('passport_number', '=', number), ('id', '!=', partner.id)], limit=1):
+                    raise ValidationError(_('Ya existe un contacto con este número de pasaporte.'))
+        # store history if number or expiration changes
+        for partner in self:
+            history_vals = {}
+            if 'passport_number' in vals and partner.passport_number and vals.get('passport_number') != partner.passport_number:
+                history_vals['old_passport_number'] = partner.passport_number
+            if 'passport_expiration_date' in vals and partner.passport_expiration_date and vals.get('passport_expiration_date') != partner.passport_expiration_date:
+                history_vals['old_expiration_date'] = partner.passport_expiration_date
+            if history_vals:
+                history_vals.update({
+                    'partner_id': partner.id,
+                    'user_id': self.env.user.id,
+                    'date': fields.Datetime.now()
+                })
+                self.env['passport.history'].create(history_vals)
+        return super().write(vals)

--- a/passport_reader/security/ir.model.access.csv
+++ b/passport_reader/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_passport_history,access_passport_history,model_passport_history,base.group_user,1,0,0,0

--- a/passport_reader/views/res_partner_views.xml
+++ b/passport_reader/views/res_partner_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_form_passport" model="ir.ui.view">
+        <field name="name">res.partner.form.passport</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/notebook" position="inside">
+                <page string="Passport">
+                    <group>
+                        <field name="passport_number"/>
+                        <field name="passport_expiration_date"/>
+                        <field name="passport_status" widget="statusbar" statusbar_visible="valid,expiring,expired"/>
+                    </group>
+                    <group string="History">
+                        <field name="passport_history_ids" readonly="1" nolabel="1" context="{'default_partner_id': active_id}"/>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- extend `res.partner` with passport fields
- track passport changes with new `passport.history`
- check duplicates and update partner on OCR scan
- add access rights and partner form view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858e3f1fd3c832cbda25ab7e07b302b