### PR TITLE
Add OCR image reading and passport expiry cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This repository contains a sample Odoo 17 module `passport_reader` which can
 read passports from images or PDF files using OCR. It manages expiration dates
-and keeps multiple passports for a contact.
+and keeps multiple passports for a contact. A new wizard allows reading
+passport data directly from an uploaded image using `pytesseract`.
 
 Install the Python dependencies from `requirements.txt` and ensure the
-`tesseract-ocr` binary is available in the system.
+`tesseract-ocr` binary is available in the system. The module also defines a
+scheduled action that posts a message on contacts whose passports are expired
+or close to expire.

--- a/passport_reader/README.md
+++ b/passport_reader/README.md
@@ -2,3 +2,5 @@
 
 Odoo module to read passports using OCR. Requires `pytesseract` and the
 Tesseract OCR binary. If PDF files are used, `pdf2image` is also needed.
+It supports extracting the passport number, issue date and expiration date from
+an uploaded image with a single click.

--- a/passport_reader/__manifest__.py
+++ b/passport_reader/__manifest__.py
@@ -7,6 +7,7 @@
     'depends': ['base'],
     'data': [
         'security/ir.model.access.csv',
+        'data/passport_expiry_cron.xml',
         'views/passport_reader_views.xml',
         'views/res_partner_views.xml',
     ],

--- a/passport_reader/data/passport_expiry_cron.xml
+++ b/passport_reader/data/passport_expiry_cron.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data noupdate="0">
+        <record id="ir_cron_passport_expiry_check" model="ir.cron">
+            <field name="name">Passport Expiry Check</field>
+            <field name="model_id" ref="base.model_res_partner"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_check_passport_expiry()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="active" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/passport_reader/models/passport_reader.py
+++ b/passport_reader/models/passport_reader.py
@@ -1,9 +1,10 @@
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 import base64
 import io
 from datetime import datetime, timedelta
+import re
 
 try:
     import pytesseract
@@ -25,8 +26,11 @@ class PassportReader(models.Model):
     contact_id = fields.Many2one('res.partner', string='Contact')
     file = fields.Binary(string='Passport File', attachment=True)
     file_filename = fields.Char()
+    passport_image = fields.Binary(string='Passport Image', attachment=True)
+    passport_image_filename = fields.Char()
     passport_number = fields.Char()
     expiration_date = fields.Date()
+    issue_date = fields.Date()
 
     _sql_constraints = [
         ('passport_contact_unique', 'unique(contact_id, passport_number)',
@@ -65,6 +69,15 @@ class PassportReader(models.Model):
             text += pytesseract.image_to_string(img)
         return text
 
+    def _extract_text_from_image(self):
+        if not self.passport_image:
+            raise UserError(_('No image to process.'))
+        if not pytesseract:
+            raise UserError(_('pytesseract is not installed.'))
+        binary = base64.b64decode(self.passport_image)
+        img = Image.open(io.BytesIO(binary))
+        return pytesseract.image_to_string(img)
+
     def parse_passport_text(self, text):
         # Very naive MRZ parser for demonstration
         if not text:
@@ -76,12 +89,34 @@ class PassportReader(models.Model):
             if len(lines) > idx + 1:
                 second = lines[idx + 1]
                 self.passport_number = second[0:9].replace('<', '')
+                exp_raw = second[21:27].replace('<', '')
+                try:
+                    self.expiration_date = datetime.strptime(exp_raw, '%y%m%d').date()
+                except Exception:
+                    pass
         # Fallback: try to find a number pattern
         if not self.passport_number:
             for line in lines:
                 if line.isalnum() and len(line) >= 6:
                     self.passport_number = line
                     break
+
+        date_candidates = []
+        for line in lines:
+            matches = re.findall(r'(\d{2}[/-]\d{2}[/-]\d{4}|\d{4}-\d{2}-\d{2})', line)
+            date_candidates.extend(matches)
+
+        def _parse_date(d):
+            for fmt in ('%d/%m/%Y', '%d-%m-%Y', '%Y-%m-%d'):
+                try:
+                    return datetime.strptime(d, fmt).date()
+                except ValueError:
+                    continue
+
+        if date_candidates:
+            self.issue_date = _parse_date(date_candidates[0]) or self.issue_date
+            if len(date_candidates) > 1 and not self.expiration_date:
+                self.expiration_date = _parse_date(date_candidates[1]) or self.expiration_date
 
         # Duplicate validation after parsing
         if self.passport_number:
@@ -90,12 +125,27 @@ class PassportReader(models.Model):
             ], limit=1)
             if existing:
                 raise UserError(_('Ya existe un contacto con este número de pasaporte.'))
+        if not self.passport_number or not self.expiration_date:
+            raise ValidationError(_("No se pudo extraer información válida del pasaporte."))
 
     def action_read_passport(self):
         for record in self:
             text = record._extract_text_from_file()
             if not text:
                 raise UserError(_('Could not read passport.'))
+            record.parse_passport_text(text)
+            if record.contact_id:
+                record.contact_id.write({
+                    'passport_number': record.passport_number,
+                    'passport_expiration_date': record.expiration_date,
+                })
+        return True
+
+    def action_read_image(self):
+        for record in self:
+            text = record._extract_text_from_image()
+            if not text:
+                raise ValidationError(_('No se pudo extraer texto de la imagen.'))
             record.parse_passport_text(text)
             if record.contact_id:
                 record.contact_id.write({
@@ -116,6 +166,10 @@ class PassportReader(models.Model):
         if 'file' in vals:
             vals.setdefault('passport_number', False)
             vals.setdefault('expiration_date', False)
+        if 'passport_image' in vals:
+            vals.setdefault('passport_number', False)
+            vals.setdefault('expiration_date', False)
+            vals.setdefault('issue_date', False)
         res = super().write(vals)
         for record in self:
             if record.is_expired():

--- a/passport_reader/models/res_partner.py
+++ b/passport_reader/models/res_partner.py
@@ -1,5 +1,6 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from datetime import timedelta
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
@@ -58,3 +59,17 @@ class ResPartner(models.Model):
                 })
                 self.env['passport.history'].create(history_vals)
         return super().write(vals)
+
+    @api.model
+    def cron_check_passport_expiry(self):
+        today = fields.Date.today()
+        soon = today + timedelta(days=90)
+        partners = self.search([('passport_expiration_date', '!=', False)])
+        for partner in partners:
+            if partner.passport_expiration_date < today:
+                msg = _('Pasaporte vencido el %s') % partner.passport_expiration_date
+            elif today <= partner.passport_expiration_date <= soon:
+                msg = _('Pasaporte próximo a vencer el %s') % partner.passport_expiration_date
+            else:
+                continue
+            partner.message_post(body=msg)

--- a/passport_reader/views/passport_reader_views.xml
+++ b/passport_reader/views/passport_reader_views.xml
@@ -12,9 +12,11 @@
                         <field name="passport_number"/>
                         <field name="expiration_date"/>
                         <field name="file" filename="file_filename"/>
+                        <field name="passport_image" filename="passport_image_filename"/>
                     </group>
                     <footer>
                         <button name="action_read_passport" type="object" string="📷 Leer pasaporte" class="btn-primary"/>
+                        <button name="action_read_image" type="object" string="📷 Leer desde imagen" class="btn-secondary"/>
                     </footer>
                 </sheet>
             </form>

--- a/passport_reader/views/res_partner_views.xml
+++ b/passport_reader/views/res_partner_views.xml
@@ -10,7 +10,7 @@
                     <group>
                         <field name="passport_number"/>
                         <field name="passport_expiration_date"/>
-                        <field name="passport_status" widget="statusbar" statusbar_visible="valid,expiring,expired"/>
+                        <field name="passport_status" widget="badge"/>
                     </group>
                     <group string="History">
                         <field name="passport_history_ids" readonly="1" nolabel="1" context="{'default_partner_id': active_id}"/>


### PR DESCRIPTION
## Summary
- integrate reading passport info from an uploaded image using pytesseract
- add issue_date and passport_image fields
- expose new button to read from image
- add daily cron job to warn about expired passports
- show passport status as badge and document the new features

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6858e6bfb170832cb97b5f4f1eaf5885